### PR TITLE
refactor: expose recovery signer context

### DIFF
--- a/src/hooks/use-validate-signer.ts
+++ b/src/hooks/use-validate-signer.ts
@@ -6,10 +6,17 @@ import compareAddress from '~/utils/compareAddress'
 
 import { useWalletRecovery } from './wallet-recovery-context'
 
+export type RecoverySignerMatch = {
+  leaf: Extensions.Recovery.RecoveryLeaf
+  extensionAddress: Address
+}
+
 /**
  * Resolves the wallet's latest config from Arweave, finds the recovery
  * sapient-signer leaf, and confirms the given signer address is present
- * as a RecoveryLeaf inside the recovery tree.
+ * as a RecoveryLeaf inside the recovery tree. Returns both the matched
+ * leaf and the recovery extension contract address (= the sapient leaf's
+ * `address`), which downstream on-chain calls need.
  *
  * Replaces `manager.recovery.getSigners(wallet)` with a direct read path
  * so recovery keeps working if Sequence's keymachine proxy is unavailable.
@@ -17,7 +24,7 @@ import { useWalletRecovery } from './wallet-recovery-context'
 export async function findRecoverySigner(
   walletAddress: Address,
   recoverySignerAddress: Address
-): Promise<Extensions.Recovery.RecoveryLeaf> {
+): Promise<RecoverySignerMatch> {
   const deploy = await arweaveReader.getDeploy(walletAddress)
   if (!deploy) {
     throw new Error('no_signers')
@@ -53,7 +60,7 @@ export async function findRecoverySigner(
     const { leaves } = Extensions.Recovery.getRecoveryLeaves(recoveryTree)
     const match = leaves.find(leaf => compareAddress(leaf.signer, recoverySignerAddress))
     if (match) {
-      return match
+      return { leaf: match, extensionAddress: sapient.address as Address }
     }
   }
 
@@ -67,11 +74,11 @@ export function useValidateSigner() {
     walletAddress: Address,
     recoverySignerAddress: Address
   ) {
-    const walletSigner = await findRecoverySigner(walletAddress, recoverySignerAddress)
+    const { leaf } = await findRecoverySigner(walletAddress, recoverySignerAddress)
 
-    set.walletSigner(walletSigner)
+    set.walletSigner(leaf)
     set.walletAddress(walletAddress)
 
-    return walletSigner
+    return leaf
   }
 }

--- a/src/stores/AuthStore.ts
+++ b/src/stores/AuthStore.ts
@@ -43,6 +43,8 @@ export class AuthStore {
 
   accountAddress = observable<string | undefined>(undefined)
 
+  recoverySignerAddress = observable<string | undefined>(undefined)
+
   async signInWithRecoveryMnemonic(wallet: string, mnemonic: string, password?: string) {
     try {
       this.isLoadingAccount.set(true)
@@ -69,6 +71,7 @@ export class AuthStore {
       }
 
       this.account = account
+      this.recoverySignerAddress.set(recoverySigner.address)
       this.accountAddress.set(account.address)
     } catch (error) {
       console.warn(error)
@@ -190,6 +193,7 @@ export class AuthStore {
   logout() {
     this.account = undefined
     this.accountAddress.set(undefined)
+    this.recoverySignerAddress.set(undefined)
     clearIndexedDB(IndexedDBKey.SECURITY)
 
     const networkStore = this.store.get(NetworkStore)

--- a/src/stores/QueuedPayloadsStore.ts
+++ b/src/stores/QueuedPayloadsStore.ts
@@ -1,33 +1,49 @@
 import compareAddress from '~/utils/compareAddress'
 import { Sequence } from '@0xsequence/wallet-wdk'
+import { Payload } from '@0xsequence/wallet-primitives'
 import { NetworkType } from '@0xsequence/network'
-import { Address } from 'viem'
+import { Address, createPublicClient, http, parseAbi, type PublicClient } from 'viem'
 
-import { manager } from '~/manager'
+import { arweaveReader } from '~/arweave-reader'
+import { findRecoverySigner } from '~/hooks/use-validate-signer'
 import { networks } from '~/networks'
 
 import { Store, observable } from '.'
 import { AuthStore } from './AuthStore'
+
+const RECOVERY_EXTENSION_ABI = parseAbi([
+  'function totalQueuedPayloads(address wallet, address signer) view returns (uint256)',
+  'function queuedPayloadHashes(address wallet, address signer, uint256 index) view returns (bytes32)',
+  'function timestampForQueuedPayload(address wallet, address signer, bytes32 payloadHash) view returns (uint256)',
+])
+
+type RecoveryContext = {
+  wallet: Address
+  signer: Address
+  extension: Address
+  requiredDeltaTime: bigint
+}
 
 export class QueuedPayloadsStore {
   isLoading = observable(true)
   payloads = observable<Sequence.QueuedRecoveryPayload[]>([])
 
   private mainnetNetworks = networks.filter(network => network.type === NetworkType.MAINNET)
-  private chains = this.mainnetNetworks.map(network => network.chainId)
+  private chains = this.mainnetNetworks
+
+  private recoveryContext: RecoveryContext | undefined
 
   constructor(private store: Store) {
-    // Subscribe to auth store changes
     const authStore = this.store.get(AuthStore)
     authStore.accountAddress.subscribe(address => {
       if (address) {
         this.fetchPayloads()
       } else {
+        this.recoveryContext = undefined
         this.clear()
       }
     })
 
-    // Initial fetch if account is already loaded
     const accountAddress = authStore.accountAddress.get()
     if (accountAddress) {
       this.fetchPayloads()
@@ -36,29 +52,59 @@ export class QueuedPayloadsStore {
     }
   }
 
+  private async ensureRecoveryContext(wallet: Address): Promise<RecoveryContext | undefined> {
+    if (this.recoveryContext && compareAddress(this.recoveryContext.wallet, wallet)) {
+      return this.recoveryContext
+    }
+
+    const authStore = this.store.get(AuthStore)
+    const signerAddress = authStore.recoverySignerAddress.get() as Address | undefined
+    if (!signerAddress) {
+      return undefined
+    }
+
+    try {
+      const match = await findRecoverySigner(wallet, signerAddress)
+      this.recoveryContext = {
+        wallet,
+        signer: signerAddress,
+        extension: match.extensionAddress,
+        requiredDeltaTime: match.leaf.requiredDeltaTime,
+      }
+      return this.recoveryContext
+    } catch (error) {
+      console.error('Error resolving recovery context for queued payloads:', error)
+      return undefined
+    }
+  }
+
   private async fetchPayloads() {
     this.isLoading.set(true)
     const authStore = this.store.get(AuthStore)
     const accountAddress = authStore.accountAddress.get() as Address | undefined
 
-    if (!this.chains || !accountAddress) {
+    if (!accountAddress || this.chains.length === 0) {
       this.isLoading.set(false)
       return
     }
 
-    // Clear existing payloads for this address
     this.clearPayloadsForAddress(accountAddress)
 
-    const fetchPromises = this.chains.map(chain => 
-      this.fetchPayloadsForChain(accountAddress, chain)
+    const context = await this.ensureRecoveryContext(accountAddress)
+    if (!context) {
+      this.isLoading.set(false)
+      return
+    }
+
+    const fetchPromises = this.chains.map(network =>
+      this.fetchPayloadsForChain(context, network.chainId, network.rpcUrl)
     )
 
     try {
       const results = await Promise.allSettled(fetchPromises)
-      
-      // Combine all successful results
+
       const allPayloads = results
-        .filter((result): result is PromiseFulfilledResult<Sequence.QueuedRecoveryPayload[]> => 
+        .filter((result): result is PromiseFulfilledResult<Sequence.QueuedRecoveryPayload[]> =>
           result.status === 'fulfilled'
         )
         .flatMap(result => result.value)
@@ -72,14 +118,66 @@ export class QueuedPayloadsStore {
   }
 
   private async fetchPayloadsForChain(
-    address: Address, 
-    chain: number
+    context: RecoveryContext,
+    chainId: number,
+    rpcUrl: string
   ): Promise<Sequence.QueuedRecoveryPayload[]> {
+    if (!rpcUrl) {
+      return []
+    }
+
     try {
-      // @ts-expect-error fetchQueuedPayloads takes, but doesn't expect chain
-      return await manager.recovery.fetchQueuedPayloads(address, chain)
+      const client: PublicClient = createPublicClient({ transport: http(rpcUrl) })
+
+      const total = await client.readContract({
+        address: context.extension,
+        abi: RECOVERY_EXTENSION_ABI,
+        functionName: 'totalQueuedPayloads',
+        args: [context.wallet, context.signer],
+      })
+
+      if (total === 0n) {
+        return []
+      }
+
+      const results: Sequence.QueuedRecoveryPayload[] = []
+
+      for (let index = 0n; index < total; index++) {
+        const payloadHash = await client.readContract({
+          address: context.extension,
+          abi: RECOVERY_EXTENSION_ABI,
+          functionName: 'queuedPayloadHashes',
+          args: [context.wallet, context.signer, index],
+        })
+
+        const timestamp = await client.readContract({
+          address: context.extension,
+          abi: RECOVERY_EXTENSION_ABI,
+          functionName: 'timestampForQueuedPayload',
+          args: [context.wallet, context.signer, payloadHash],
+        })
+
+        const payloadRecord = await arweaveReader.getPayload(payloadHash)
+
+        const id = `${index}-${context.signer}-${chainId}-${context.wallet}`
+
+        results.push({
+          id,
+          index,
+          recoveryModule: context.extension,
+          wallet: context.wallet,
+          signer: context.signer,
+          chainId,
+          startTimestamp: timestamp,
+          endTimestamp: timestamp + context.requiredDeltaTime,
+          payloadHash,
+          payload: payloadRecord?.payload as Payload.Payload | undefined,
+        })
+      }
+
+      return results
     } catch (error) {
-      console.error(`Error fetching payloads for chain ${chain}:`, error)
+      console.error(`Error fetching payloads for chain ${chainId}:`, error)
       return []
     }
   }
@@ -97,10 +195,9 @@ export class QueuedPayloadsStore {
 
     const current = this.payloads.get()
     const merged = [...current, ...newPayloads]
-    
-    // Remove duplicates based on payload id
+
     const unique = [...new Map(merged.map(item => [item.id, item])).values()]
-    
+
     this.payloads.set(unique)
   }
 


### PR DESCRIPTION
## Summary

- Extend recovery signer validation to return the recovery extension address, sapient image hash, deploy context, wallet config, and pending config updates.
- Track the mnemonic-derived recovery signer address in AuthStore for later queue and execute operations.
- Start resolving queued payload context from Arweave-derived signer metadata instead of Manager state.

## Stack

1. review/arweave-read-path
2. This PR: review/recovery-context -> review/arweave-read-path
3. review/direct-recovery-execute
4. review/direct-recovery-queue
5. review/remove-wallet-wdk

## Validation

- pnpm typecheck passed on this branch.
- Full stack was manually tested locally by Mithat.

Draft while the full recovery stack is reviewed.