### PR TITLE
feat: build recovery execute transactions locally

### DIFF
--- a/src/hooks/use-execute-recovery.ts
+++ b/src/hooks/use-execute-recovery.ts
@@ -1,89 +1,42 @@
+import { Payload } from '@0xsequence/wallet-primitives'
 import { Address } from 'viem'
-import { manager } from '~/manager'
 
-export async function executeRecovery(
-  walletAddress: Address,
-  calls: any[],
-  space: bigint,
-  nonce: bigint,
+import { buildRecoveryExecuteTx } from '~/recovery-execute'
+import { findRecoverySigner } from './use-validate-signer'
+
+export type SendRecoveryTx = (
+  to: `0x${string}`,
+  data: `0x${string}`,
   chainId: number,
-  callback: (status: string) => void,
-  provider: any
-) {
-  const txId = await manager.transactions.request(
-    walletAddress!,
+  recoveryPayloadId?: string
+) => Promise<{ id: string | undefined; hash: `0x${string}` } | undefined>
+
+export type ExecuteRecoveryParams = {
+  walletAddress: Address
+  recoverySignerAddress: Address
+  payload: Payload.Calls
+  chainId: number
+  sendTx: SendRecoveryTx
+  recoveryPayloadId?: string
+}
+
+export async function executeRecovery({
+  walletAddress,
+  recoverySignerAddress,
+  payload,
+  chainId,
+  sendTx,
+  recoveryPayloadId,
+}: ExecuteRecoveryParams) {
+  const match = await findRecoverySigner(walletAddress, recoverySignerAddress)
+
+  const tx = await buildRecoveryExecuteTx({
+    walletAddress,
+    recoverySignerAddress,
+    payload,
     chainId,
-    calls,
-    {
-      noConfigUpdate: true,
-      source: 'recovery_payload',
-    }
-  )
-
-
-  await manager.transactions.define(txId, {
-    nonce,
-    space,
+    match,
   })
 
-  const transaction = await manager.transactions
-    .get(txId)
-    .then(s => s)
-    .catch(e => console.log('catch', e))
-
-  if (!transaction || transaction.status !== 'defined') {
-    await manager.transactions.delete(txId)
-    throw new Error('Transaction not found or unexpected status')
-  }
-
-  const relayerOptions = provider
-    ? transaction.relayerOptions.find(
-      option => option.relayerId === provider.info.uuid
-    )
-    : transaction.relayerOptions.find(
-      option => option.kind === 'standard' && !option.feeOption
-    )
-
-  if (!relayerOptions) {
-    await manager.transactions.delete(txId)
-    throw new Error('No free relayer options found')
-  }
-
-  const requestId = await manager.transactions.selectRelayer(
-    txId,
-    relayerOptions.id
-  )
-  manager.signatures.onSignatureRequestUpdate(
-    requestId,
-    async request => {
-      if (request.status !== 'pending') { return }
-      const actionSigner = request.signers.find(
-        signer =>
-          signer.handler?.kind === 'recovery-extension' &&
-          signer.status === 'ready'
-      )
-
-      if (!actionSigner) { return }
-
-      if (actionSigner.status === 'ready') {
-        actionSigner.handle().then(async () => {
-          manager.transactions.relay(txId).catch(e => {
-            if (e && e.code && e.code === 4001) {
-              manager.transactions.delete(txId)
-              callback('cancelled')
-            }
-          })
-        })
-      }
-    },
-    error => {
-      console.error(
-        'Error fetching signature request:',
-        error
-      )
-    },
-    true
-  )
-
-  return txId
+  return sendTx(tx.to, tx.data, chainId, recoveryPayloadId)
 }

--- a/src/hooks/use-payload-execution.ts
+++ b/src/hooks/use-payload-execution.ts
@@ -1,37 +1,60 @@
-import { useState, useEffect } from "react"
-import { Sequence } from "@0xsequence/wallet-wdk"
-import { manager } from "~/manager"
-import { executeRecovery } from "./use-execute-recovery"
+import { useState, useEffect } from 'react'
+import { Sequence } from '@0xsequence/wallet-wdk'
+import { Constants } from '@0xsequence/wallet-primitives'
+import { AbiFunction } from 'ox'
+import { Address, createPublicClient, hexToBigInt, http, type PublicClient } from 'viem'
+
+import { networks } from '~/networks'
+import { useObservable, useStore } from '~/stores'
+import { AuthStore } from '~/stores/AuthStore'
+import { useWalletRecovery } from './wallet-recovery-context'
+import { executeRecovery } from './use-execute-recovery'
 
 interface UsePayloadExecutionParams {
   payload: Sequence.QueuedRecoveryPayload
   selectedExternalProvider: any
 }
 
-export function usePayloadExecution({ payload, selectedExternalProvider }: UsePayloadExecutionParams) {
-  const [isExecuted, setIsExecuted] = useState(false)
-  const [txId, setTxId] = useState<string | null>(null)
-  const [isPending, setIsPending] = useState(false)
-  const [transaction, setTransaction] = useState<Sequence.Transaction | null>(null)
+type ExecStatus = 'idle' | 'pending' | 'final'
+type OpStatus = null | 'confirmed' | 'failed'
 
-  // Check if payload has already been executed
+export function usePayloadExecution({ payload, selectedExternalProvider }: UsePayloadExecutionParams) {
+  const { handle: { sendRecoveryPayload } } = useWalletRecovery()
+  const authStore = useStore(AuthStore)
+  const recoverySignerAddress = useObservable(authStore.recoverySignerAddress)
+
+  const [isExecuted, setIsExecuted] = useState(false)
+  const [isPending, setIsPending] = useState(false)
+  const [hash, setHash] = useState<`0x${string}` | null>(null)
+  const [status, setStatus] = useState<ExecStatus>('idle')
+  const [opStatus, setOpStatus] = useState<OpStatus>(null)
+
+  const rpcUrl = networks.find(n => n.chainId === payload.chainId)?.rpcUrl
+
   useEffect(() => {
     async function checkIfExecuted() {
       try {
         // @ts-expect-error payload.payload.space and nonce exist at runtime
-        const space = payload.payload?.space
+        const space: bigint | undefined = payload.payload?.space
         // @ts-expect-error payload.payload.nonce exists at runtime
-        const payloadNonce = payload.payload?.nonce
+        const payloadNonce: bigint | undefined = payload.payload?.nonce
 
-        if (space !== undefined && payloadNonce !== undefined) {
-          const currentNonce = await manager.wallets.getNonce(
-            payload.chainId,
-            payload.wallet,
-            space
-          )
-          // If current nonce is greater than payload nonce, it has been executed
-          setIsExecuted(currentNonce > payloadNonce)
+        if (space === undefined || payloadNonce === undefined || !rpcUrl) {
+          return
         }
+
+        const client: PublicClient = createPublicClient({ transport: http(rpcUrl) })
+        const result = await client.call({
+          to: payload.wallet,
+          data: AbiFunction.encodeData(Constants.READ_NONCE, [space]) as `0x${string}`,
+        })
+
+        if (!result.data) {
+          return
+        }
+
+        const currentNonce = hexToBigInt(result.data)
+        setIsExecuted(currentNonce > payloadNonce)
       } catch (error) {
         console.error('Error checking if payload is executed:', error)
       }
@@ -39,71 +62,100 @@ export function usePayloadExecution({ payload, selectedExternalProvider }: UsePa
 
     checkIfExecuted()
     // @ts-expect-error payload.payload.space and nonce exist at runtime
-  }, [payload.chainId, payload.wallet, payload.payload?.space, payload.payload?.nonce])
+  }, [payload.chainId, payload.wallet, payload.payload?.space, payload.payload?.nonce, rpcUrl])
 
-  // Monitor transaction updates
   useEffect(() => {
-    if (txId) {
-      manager.transactions
-        .get(txId)
-        .then(tx => {
-          manager.transactions.onTransactionUpdate(
-            tx.id,
-            handleTransactionUpdate,
-            true
-          )
-        })
-        .catch(e => {
-          console.log('Error getting transaction:', e)
-        })
+    if (!hash || !rpcUrl) {
+      return
     }
-  }, [txId])
 
-  function handleTransactionUpdate(tx: Sequence.Transaction) {
-    if (tx) {
-      setTransaction(tx)
+    const client: PublicClient = createPublicClient({ transport: http(rpcUrl) })
+    let cancelled = false
+
+    client
+      .waitForTransactionReceipt({ hash })
+      .then(receipt => {
+        if (cancelled) {
+          return
+        }
+        setStatus('final')
+        setOpStatus(receipt.status === 'success' ? 'confirmed' : 'failed')
+        if (receipt.status === 'success') {
+          setIsExecuted(true)
+        }
+        setIsPending(false)
+      })
+      .catch(error => {
+        if (cancelled) {
+          return
+        }
+        console.error('Error waiting for tx receipt:', error)
+        setStatus('final')
+        setOpStatus('failed')
+        setIsPending(false)
+      })
+
+    return () => {
+      cancelled = true
     }
-  }
+  }, [hash, rpcUrl])
 
   const handleExecuteRecovery = async () => {
-    setIsPending(true)
-    
-    const txId = await executeRecovery(
-      payload.wallet,
-      // @ts-expect-error TODO fix this. payload.payload should have calls
-      payload.payload?.calls,
-      // @ts-expect-error TODO fix this. payload.payload should have space
-      payload.payload.space,
-      // @ts-expect-error TODO fix this. payload.payload should have nonce
-      payload.payload.nonce,
-      payload.chainId,
-      () => {
-        setIsPending(false)
-      },
-      selectedExternalProvider
-    )
+    if (!recoverySignerAddress || !sendRecoveryPayload) {
+      return
+    }
 
-    if (txId) {
-      setTxId(txId)
+    setIsPending(true)
+    setStatus('idle')
+    setOpStatus(null)
+    setHash(null)
+
+    try {
+      console.log('[use-payload-execution] queued payload from store', {
+        id: payload.id,
+        wallet: payload.wallet,
+        signer: payload.signer,
+        chainId: payload.chainId,
+        recoveryModule: payload.recoveryModule,
+        onChainPayloadHash: payload.payloadHash,
+        startTimestamp: String(payload.startTimestamp),
+        endTimestamp: String(payload.endTimestamp),
+        payloadRaw: payload.payload,
+      })
+
+      const result = await executeRecovery({
+        walletAddress: payload.wallet as Address,
+        recoverySignerAddress: recoverySignerAddress as Address,
+        // @ts-expect-error payload.payload is Payload.Calls at runtime
+        payload: payload.payload,
+        chainId: payload.chainId,
+        sendTx: sendRecoveryPayload,
+        recoveryPayloadId: payload.id,
+      })
+
+      if (result?.hash) {
+        setHash(result.hash)
+      } else {
+        setIsPending(false)
+      }
+    } catch (error) {
+      console.error('Error executing recovery:', error)
+      setIsPending(false)
     }
   }
 
-  const hash = transaction?.status === 'final' 
-    ? transaction?.opStatus.status === 'confirmed' 
-      ? transaction?.opStatus.transactionHash 
-      : null 
-    : null
-
-  const status = transaction?.status
-  const opStatus = status === 'final' ? transaction?.opStatus.status : null
+  // Keep `selectedExternalProvider` referenced — UI passes it in but the
+  // execution itself goes through `sendRecoveryPayload`, which already uses
+  // the same provider via WalletStore.
+  void selectedExternalProvider
 
   return {
     isExecuted,
     isPending,
-    transaction,
+    transaction: null,
     hash,
-    status,
+    status: status === 'idle' ? undefined : status,
     opStatus,
-    handleExecuteRecovery
+    handleExecuteRecovery,
   }
 }

--- a/src/hooks/use-validate-signer.ts
+++ b/src/hooks/use-validate-signer.ts
@@ -1,4 +1,4 @@
-import { Config, Extensions } from '@0xsequence/wallet-primitives'
+import { Config, Context, Extensions, Signature } from '@0xsequence/wallet-primitives'
 import { Address } from 'viem'
 
 import { arweaveReader } from '~/arweave-reader'
@@ -9,6 +9,12 @@ import { useWalletRecovery } from './wallet-recovery-context'
 export type RecoverySignerMatch = {
   leaf: Extensions.Recovery.RecoveryLeaf
   extensionAddress: Address
+  sapientImageHash: `0x${string}`
+  deployImageHash: `0x${string}`
+  walletConfig: Config.Config
+  deployContext: Context.Context
+  /** Pending config updates in reverse chronological order (newest first). */
+  pendingUpdates: Array<{ imageHash: `0x${string}`; signature: Signature.RawSignature }>
 }
 
 /**
@@ -32,6 +38,10 @@ export async function findRecoverySigner(
 
   const updates = await arweaveReader.getConfigurationUpdates(walletAddress, deploy.imageHash)
   const latestImageHash = updates.length > 0 ? updates[updates.length - 1].imageHash : deploy.imageHash
+  const pendingUpdates = [...updates].reverse() as Array<{
+    imageHash: `0x${string}`
+    signature: typeof updates[number]['signature']
+  }>
 
   const config = await arweaveReader.getConfiguration(latestImageHash)
   if (!config) {
@@ -60,7 +70,15 @@ export async function findRecoverySigner(
     const { leaves } = Extensions.Recovery.getRecoveryLeaves(recoveryTree)
     const match = leaves.find(leaf => compareAddress(leaf.signer, recoverySignerAddress))
     if (match) {
-      return { leaf: match, extensionAddress: sapient.address as Address }
+      return {
+        leaf: match,
+        extensionAddress: sapient.address as Address,
+        sapientImageHash: sapient.imageHash as `0x${string}`,
+        deployImageHash: deploy.imageHash as `0x${string}`,
+        walletConfig: config,
+        deployContext: deploy.context,
+        pendingUpdates,
+      }
     }
   }
 

--- a/src/recovery-execute.ts
+++ b/src/recovery-execute.ts
@@ -1,0 +1,151 @@
+import {
+  Constants,
+  Extensions,
+  Payload,
+  Signature as PrimitiveSignature,
+} from '@0xsequence/wallet-primitives'
+import { AbiFunction, Bytes, Hex } from 'ox'
+import { createPublicClient, http } from 'viem'
+import compareAddress from '~/utils/compareAddress'
+import { arweaveReader } from '~/arweave-reader'
+import type { RecoverySignerMatch } from '~/hooks/use-validate-signer'
+import { networks } from '~/networks'
+
+export type BuildRecoveryExecuteParams = {
+  walletAddress: `0x${string}`
+  recoverySignerAddress: `0x${string}`
+  payload: Payload.Calls
+  chainId: number
+  match: RecoverySignerMatch
+}
+
+export type RecoveryExecuteTx = {
+  to: `0x${string}`
+  data: `0x${string}`
+}
+
+const ZERO_HASH = `0x${'0'.repeat(64)}` as `0x${string}`
+
+type ExecutionWalletState = {
+  walletConfig: RecoverySignerMatch['walletConfig']
+  pendingUpdates: RecoverySignerMatch['pendingUpdates']
+}
+
+async function readStage2ImageHash(
+  walletAddress: `0x${string}`,
+  chainId: number,
+  match: RecoverySignerMatch,
+): Promise<`0x${string}` | undefined> {
+  const rpcUrl = networks.find(network => network.chainId === chainId)?.rpcUrl
+  if (!rpcUrl) {
+    throw new Error('rpc_not_found')
+  }
+
+  const client = createPublicClient({ transport: http(rpcUrl) })
+
+  let implementation: `0x${string}` | undefined
+  try {
+    const result = await client.call({
+      to: walletAddress,
+      data: AbiFunction.encodeData(Constants.GET_IMPLEMENTATION) as `0x${string}`,
+    })
+
+    if (result.data && result.data.length >= 42) {
+      implementation = `0x${result.data.slice(-40)}` as `0x${string}`
+    }
+  } catch {
+    return undefined
+  }
+
+  if (!implementation || !compareAddress(implementation, match.deployContext.stage2)) {
+    return undefined
+  }
+
+  const imageHash = await client.call({
+    to: walletAddress,
+    data: AbiFunction.encodeData(Constants.IMAGE_HASH) as `0x${string}`,
+  })
+
+  if (!imageHash.data || imageHash.data === ZERO_HASH) {
+    throw new Error('onchain_image_hash_not_found')
+  }
+
+  return imageHash.data as `0x${string}`
+}
+
+async function getExecutionWalletState(
+  walletAddress: `0x${string}`,
+  chainId: number,
+  match: RecoverySignerMatch,
+): Promise<ExecutionWalletState> {
+  const onChainImageHash = await readStage2ImageHash(walletAddress, chainId, match)
+    ?? match.deployImageHash
+  const updates = await arweaveReader.getConfigurationUpdates(walletAddress, onChainImageHash)
+  const latestImageHash = updates.length > 0
+    ? updates[updates.length - 1].imageHash
+    : onChainImageHash
+
+  const walletConfig = await arweaveReader.getConfiguration(latestImageHash)
+  if (!walletConfig) {
+    throw new Error('wallet_config_not_found')
+  }
+
+  return {
+    walletConfig,
+    pendingUpdates: [...updates].reverse() as RecoverySignerMatch['pendingUpdates'],
+  }
+}
+
+export async function buildRecoveryExecuteTx({
+  walletAddress,
+  recoverySignerAddress,
+  payload,
+  chainId,
+  match,
+}: BuildRecoveryExecuteParams): Promise<RecoveryExecuteTx> {
+  const executionState = await getExecutionWalletState(walletAddress, chainId, match)
+  const genericTree = await arweaveReader.getTree(match.sapientImageHash)
+  if (!genericTree) {
+    throw new Error('recovery_tree_not_found')
+  }
+
+  const recoveryTree = Extensions.Recovery.fromGenericTree(genericTree)
+  const trimmed = Extensions.Recovery.trimTopology(recoveryTree, recoverySignerAddress)
+  const sapientSigData = Extensions.Recovery.encodeTopology(trimmed)
+
+  const filledTopology = PrimitiveSignature.fillLeaves(executionState.walletConfig.topology, leaf => {
+    if (
+      'imageHash' in leaf &&
+      leaf.imageHash === match.sapientImageHash &&
+      compareAddress(leaf.address, match.extensionAddress)
+    ) {
+      return {
+        type: 'sapient_compact',
+        address: match.extensionAddress,
+        data: Hex.fromBytes(sapientSigData),
+      }
+    }
+    return undefined
+  })
+
+  const rawSignature: PrimitiveSignature.RawSignature = {
+    noChainId: false,
+    configuration: { ...executionState.walletConfig, topology: filledTopology },
+    suffix: executionState.pendingUpdates.length > 0
+      ? executionState.pendingUpdates.map(u => u.signature)
+      : undefined,
+  }
+
+  const sigBytes = PrimitiveSignature.encodeSignature(rawSignature)
+  const payloadBytes = Payload.encode(payload)
+
+  const data = AbiFunction.encodeData(Constants.EXECUTE, [
+    Bytes.toHex(payloadBytes),
+    Bytes.toHex(sigBytes),
+  ])
+
+  return {
+    to: walletAddress,
+    data: data as `0x${string}`,
+  }
+}


### PR DESCRIPTION
## Summary

- Replace the Sequence Manager transaction and relayer execution path with local wallet execute calldata generation.
- Build the sapient compact recovery signature from Arweave state.
- Append pending configuration update signatures when executing against the latest wallet config.
- Track execution with the external wallet transaction hash and viem receipts.

## Stack

1. review/arweave-read-path
2. review/recovery-context
3. This PR: review/direct-recovery-execute -> review/recovery-context
4. review/direct-recovery-queue
5. review/remove-wallet-wdk

## Validation

- pnpm typecheck passed on this branch.
- Full stack was manually tested locally by Mithat.

Draft while the full recovery stack is reviewed.